### PR TITLE
Make text pasting more user-friendly

### DIFF
--- a/marv/classes/text_box.lua
+++ b/marv/classes/text_box.lua
@@ -623,13 +623,9 @@ function TextBox:mouseScroll(x, y)
 end
 
 function TextBox:typeString(str)
-    for c in str:gmatch(".") do
-        if c == '\n' then
-            self:keyPressed('return')
-        elseif c == ' ' then
-            self:keyPressed('space')
-        else
-            self:textInput(c)
-        end
-    end
+    str = str:gsub('.',
+        function (c)
+            return c == '\n' and c or self.accepted_chars[c] or ''
+        end)
+    self:tryWrite(str)
 end


### PR DESCRIPTION
This is one possible fix for #226. Note there are more callers to `typeString`, so those need to be checked. In particular, I've noticed that one side effect of this patch is that when using undo on a puzzle you've just opened which you already worked on, the whole text is removed at once now (as opposed to undoing one character at a time, which is how it works without the patch). I don't think that's a significant change, though. It may be considered an issue that undo works in that situation, in the first place (editors usually don't allow undo right after opening an existing file), but it's one that doesn't bother me.