### PR TITLE
Implement breakpoint feature

### DIFF
--- a/marv/classes/step_manager.lua
+++ b/marv/classes/step_manager.lua
@@ -85,6 +85,14 @@ local function stepCallback()
         end
     end
 
+    if not sm.cmd then
+        -- check if we hit a breakpoint
+        local next_line = sm.code.real_line[sm.code.cur]
+        if Util.findId("code_tab"):isBreakPoint(next_line) then
+            sm.pause()
+        end
+    end
+
     -- Creates 1-turn stuff (lasers) (after action)
     ROOM:createEphemeral()
 
@@ -210,10 +218,11 @@ function sm.stop(fail_title, fail_text, fail_button, replay_speed, show_popup)
         sm.clear(false)
         -- Just to be sure we aren't forgetting to clean anything
         -- And this should be a pretty fast procedure
-        local bk = Util.findId('code_tab').term.backups -- does not loose history
+        local term = Util.findId('code_tab').term
+        local bk, breakpoints = term.backups, term.breakpoints -- preserve history and breakpoints
         ROOM:connect(ROOM.puzzle_id, false)
         if replay_speed then doPlay(replay_speed) end
-        Util.findId('code_tab').term.backups = bk
+        term.backups, term.breakpoints = bk, breakpoints
     end
 
     if show_popup == false or fail_title == 'no kill' then

--- a/marv/classes/tabs/code.lua
+++ b/marv/classes/tabs/code.lua
@@ -191,7 +191,13 @@ function CodeTab:mousePressed(x, y, but)
     if TABS_LOCK > 0 then return end
     for _, b in ipairs(self.buttons) do b:mousePressed(x, y, but) end
 
-    if self.lock > 0 then return end
+    if self.lock > 0 then
+        if not typingRegister(self) then
+            self.term:mousePressed(x, y, but, true)
+        end
+        return
+    end
+
     local t = typingRegister(self) and self.memory.tbox or self.term
     t:mousePressed(x, y, but)
     self:checkErrors()
@@ -208,6 +214,7 @@ function CodeTab:mouseReleased(x, y, but)
 end
 
 function CodeTab:mouseMoved(x, y)
+    self.term:mouseMoved(x, y)
     self.memory:mouseMoved(x, y)
 end
 
@@ -256,6 +263,10 @@ end
 
 function CodeTab:showLine(i)
     self.term.exec_line = i
+end
+
+function CodeTab:isBreakPoint(i)
+    return self.term.breakpoints[i]
 end
 
 function CodeTab:saveCurrentCode()

--- a/marv/classes/text_box.lua
+++ b/marv/classes/text_box.lua
@@ -256,9 +256,15 @@ function TextBox:draw(bad_lines)
         local x = self.pos.x + (self.max_char + (self.show_line_num and 4 or 0)) * self.font_w
         local y = self.pos.y - self.dy * self.line_h + (self.exec_line - 1) * self.line_h
         local dy = (self.line_h - h) / 2
-        love.graphics.polygon("fill", x, y + dy + h / 2, x + h, y + dy, x + h, y + dy + h)
-        love.graphics.setLineWidth(.1)
-        love.graphics.line(x, y + self.line_h, self.pos.x + (self.show_line_num and 4 or 0) * self.font_w, y + self.line_h)
+        if not self.breakpoints[self.exec_line+1] then
+            local w = x - self.pos.x + (self.show_line_num and 4 or 0) * self.font_w
+            local x = self.pos.x + (self.show_line_num and 4 or 0) * self.font_w
+            love.graphics.setLineWidth(.2)
+            love.graphics.rectangle("line", x, y, w, self.line_h, 1)
+        else
+            love.graphics.setLineWidth(.1)
+            love.graphics.line(x, y + self.line_h, self.pos.x + (self.show_line_num and 4 or 0) * self.font_w, y + self.line_h)
+        end
     end
 
     -- Remove stencil


### PR DESCRIPTION
Breakpoints work like in pretty much any IDE: Clicking a line number toggles a breakpoint, execution pauses before that instruction. The feature should probably be mentioned in some tutorial email, but I'm not sure where it might fit best.

Tiny issue: It's currently not possible to enable or disable breakpoints when the code tab is locked, i.e. while the program is running.