### PR TITLE
Remove duplicate jmp instruction example

### DIFF
--- a/marv/classes/tabs/manual_items.lua
+++ b/marv/classes/tabs/manual_items.lua
@@ -75,9 +75,6 @@ t.jmp = {
     command = t.jmp2.command,
     text = t.jmp2.text,
     examples = {t.jmp2.examples[1], t.jmp2.examples[2], {[[
-{labm}lp: {instm}turn {dirm}counter
-{instm}walk {numm}1
-{instm}jmp {labm}lp]], "This code will make the bot walk endlessly in a 2x2 square, in counterclockwise direction."}, {[[
 {cmntm}# Advanced Example
 {labm}func: {instm}walkc {numm}1
 {instm}turn {dirm}clock


### PR DESCRIPTION
The removed example is already present in the previous 2 documentation versions of the `jmp` instruction and was carried over already.
![image](https://user-images.githubusercontent.com/17548736/140024107-3c0a9e31-3cc6-40da-be1a-fae7421ddc2f.png)
